### PR TITLE
Support Laravel 13, Drop Legacy Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,38 +4,24 @@ on: [push, pull_request]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
+
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        php: [8.3, 8.2, 8.1, 8.0]
-        laravel: ["^12.0", "^11.0", "^10.0", "^9.0", "^8.12"]
-        dependency-version: [prefer-lowest, prefer-stable]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [^11.0, ^12.0, ^13.0]
+        dependency-version: [prefer-stable]
         include:
+          - laravel: ^13.0
+            testbench: 11.*
           - laravel: ^12.0
             testbench: 10.*
           - laravel: ^11.0
             testbench: 9.*
-          - laravel: ^10.0
-            testbench: 8.*
-          - laravel: ^9.0
-            testbench: 7.*
-          - laravel: ^8.12
-            testbench: ^6.23
         exclude:
-          - laravel: ^8.12
-            php: 8.3
-          - laravel: ^10.0
-            php: 8.0
-          - laravel: ^11.0
-            php: 8.0
-          - laravel: ^11.0
-            php: 8.1   
-          - laravel: ^12.0
-            php: 8.0
-          - laravel: ^12.0
-            php: 8.1   
+          - laravel: ^13.0
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -51,15 +37,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ matrix.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
-
-      # - name: Cache dependencies
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.composer/cache/files
-      #     key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}   
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -72,9 +52,6 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
-
-      - name: Display PHP version
-        run: php -v | grep ^PHP | cut -d' ' -f2
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](https://banners.beyondco.de/Laravel%20Redirect%20Response%20Macros.png?theme=light&packageManager=composer+require&packageName=f9webltd%2Flaravel-redirect-response-macros&pattern=brickWall&style=style_1&description=Some+super+useful+redirect+response+macros+to+simplify+your+Laravel+application&md=1&showWatermark=0&fontSize=100px&images=code)
 
-
+[![PHP ^8.2](https://img.shields.io/badge/php-%5E8.2-brightgreen)]()
 [![Packagist Version](https://img.shields.io/packagist/v/f9webltd/laravel-redirect-response-macros?style=flat-square)](https://packagist.org/packages/f9webltd/laravel-redirect-response-macros)
 [![Run Tests](https://github.com/f9webltd/laravel-redirect-response-macros/actions/workflows/run-tests.yml/badge.svg?branch=master)](https://github.com/f9webltd/laravel-redirect-response-macros/actions/workflows/run-tests.yml)
 [![StyleCI Status](https://github.styleci.io/repos/278581318/shield)](https://github.styleci.io/repos/278581318)
@@ -12,12 +12,14 @@ Some super useful redirect response macros to simplify your Laravel application.
 
 ## Requirements
 
-- PHP `^8.0`
-- Laravel `^8.12`, `^9.0`, `^10.0`, `^11.0` or `^12.0`
+* PHP `^8.2`
+* Laravel `^11.0` / `^12.0` / `^13.0`
+
+The package supports actively supported Laravel releases as per the official [Laravel Support Policy](https://laravel.com/docs/master/releases#support-policy).
 
 ### Legacy Support
 
-For legacy PHP / Laravel support, use package version [`1.1.6`](https://github.com/f9webltd/laravel-redirect-response-macros/tree/1.1.6)
+For legacy PHP / Laravel support, use package version [`2.1.0`](https://github.com/f9webltd/laravel-redirect-response-macros/tree/2.1.0)
 
 ## Installation
 
@@ -238,6 +240,7 @@ If you discover any security related issues, please email rob@f9web.co.uk instea
 ## Credits
 
 - [Rob Allport](https://github.com/ultrono) for [F9 Web Ltd.](https://www.f9web.co.uk)
+- [All Contributors](https://github.com/f9webltd/laravel-response-macros/graphs/contributors)
 
 ## License
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading
 
+## From 2.x to 3.x
+
+- Run the following command to fetch the latest package version: `composer require f9webltd/laravel-redirect-response-macros:^3.0`
+- The package now requires PHP `^8.2` and Laravel `^11.0` / `^12.0` or `^13.0`. Going forwards this package will actively track supported Laravel / PHP versions as per [Laravel's official support policy](https://laravel.com/docs/master/releases#support-policy)
+- No further changes are required, the API remains unchanged
+
 ## From 1.x to 2.x
 
 - The package now requires PHP `^8.0` and Laravel `^8.12` / `^9.0`, `^10.0` or `^11.0`

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -11,15 +11,9 @@ use function resolve;
 class MessageTest extends TestCase
 {
     /**
-     * @param  string  $method
-     * @param  string  $sessionKey
-     * @param  string  $expectedMessage
-     * @param  string|null  $arguments
-     *
-     * @test
      * @dataProvider responseData
      */
-    public function it_renders_expected_flash_data(
+    public function test_it_renders_expected_flash_data(
         string $method,
         string $sessionKey,
         string $expectedMessage,
@@ -35,8 +29,7 @@ class MessageTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_renders_exception_object_messages()
+    public function test_it_renders_exception_object_messages()
     {
         $exception = new Exception($message = 'Holy Rheostat!');
 


### PR DESCRIPTION
Support Laravel 13, Drop Legacy Support. 

Going forwards, the package will actively only track supported Laravel releases as per the official [Laravel Support Policy](https://laravel.com/docs/master/releases#support-policy).